### PR TITLE
add block opening brace newline after check

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -4,6 +4,7 @@ vala_precompile (LIB_VALA_C
     Check.vala
     FormatMistake.vala
     Checks/TrailingWhitespaceCheck.vala
+    Checks/BlockOpeningBraceNewlineAfterCheck.vala
 PACKAGES
     gio-2.0
     gee-0.8

--- a/lib/Checks/BlockOpeningBraceNewlineAfterCheck.vala
+++ b/lib/Checks/BlockOpeningBraceNewlineAfterCheck.vala
@@ -31,10 +31,12 @@ public class ValaLint.Checks.BlockOpeningBraceNewlineAfterCheck : Check {
 
         if ("{" in line ) {
             string last_char = line.substring (line.length - 1, 1);
-            if (last_char != "{" && last_char != ";") {
-                mistake_list.add ({ this, line_index + 1, line.length, _("Expected newline after '{' of a multi-line block")});
-
-                return true;
+            if (last_char != "{" && last_char != "}") {
+                string last_two_char = line.substring (line.length - 2, 2);
+                if (last_two_char != "};") {
+                    mistake_list.add ({ this, line_index + 1, line.length, _("Expected newline after '{' of a multi-line block")});
+                    return true;
+                }
             }
         }
 

--- a/lib/Checks/BlockOpeningBraceNewlineAfterCheck.vala
+++ b/lib/Checks/BlockOpeningBraceNewlineAfterCheck.vala
@@ -37,7 +37,7 @@ public class ValaLint.Checks.BlockOpeningBraceNewlineAfterCheck : Check {
                     if ("({" in line && last_two_char == ");") {
                         return false;
                     } else {
-                        mistake_list.add ({ this, line_index + 1, line.length, _("Expected newline after '{' of a multi-line block")});
+                        mistake_list.add ({ this, line_index, line.length, _("Expected newline after '{' of a multi-line block")});
                         return true;
                     }
                 }

--- a/lib/Checks/BlockOpeningBraceNewlineAfterCheck.vala
+++ b/lib/Checks/BlockOpeningBraceNewlineAfterCheck.vala
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016 elementary LLC (https://github.com/elementary/Vala-Lint)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ */
+
+public class ValaLint.Checks.BlockOpeningBraceNewlineAfterCheck : Check {
+    public override string get_title () {
+        return _("block-opening-brace-newline-after");
+    }
+
+    public override string get_description () {
+        return _("Checks for newlines after an opening brace");
+    }
+
+    public override bool check_line (Gee.ArrayList<FormatMistake?> mistake_list, int line_index, string line) {
+
+        if ("{" in line ) {
+            string last_char = line.substring (line.length - 1, 1);
+            if (last_char != "{" && last_char != ";") {
+                mistake_list.add ({ this, line_index + 1, line.length, _("Expected newline after '{' of a multi-line block")});
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/lib/Checks/BlockOpeningBraceNewlineAfterCheck.vala
+++ b/lib/Checks/BlockOpeningBraceNewlineAfterCheck.vala
@@ -24,7 +24,7 @@ public class ValaLint.Checks.BlockOpeningBraceNewlineAfterCheck : Check {
     }
 
     public override string get_description () {
-        return _("Checks for newlines after an opening brace");
+        return _("Checks for newlines after an opening brace for code blocks");
     }
 
     public override bool check_line (Gee.ArrayList<FormatMistake?> mistake_list, int line_index, string line) {

--- a/lib/Checks/BlockOpeningBraceNewlineAfterCheck.vala
+++ b/lib/Checks/BlockOpeningBraceNewlineAfterCheck.vala
@@ -34,8 +34,12 @@ public class ValaLint.Checks.BlockOpeningBraceNewlineAfterCheck : Check {
             if (last_char != "{" && last_char != "}") {
                 string last_two_char = line.substring (line.length - 2, 2);
                 if (last_two_char != "};") {
-                    mistake_list.add ({ this, line_index + 1, line.length, _("Expected newline after '{' of a multi-line block")});
-                    return true;
+                    if ("({" in line && last_two_char == ");") {
+                        return false;
+                    } else {
+                        mistake_list.add ({ this, line_index + 1, line.length, _("Expected newline after '{' of a multi-line block")});
+                        return true;
+                    }
                 }
             }
         }

--- a/lib/Linter.vala
+++ b/lib/Linter.vala
@@ -24,6 +24,7 @@ public class ValaLint.Linter : Object {
 
     public Linter () {
         enabled_checks = new Gee.ArrayList<Check> ();
+        enabled_checks.add (new Checks.BlockOpeningBraceNewlineAfterCheck ());
         enabled_checks.add (new Checks.TrailingWhitespaceCheck ());
     }
 


### PR DESCRIPTION
This check makes sure that lines containing "{" end with something that makes sense

This should stop stuff like "public var { set;" but allow "public var { get; set; }" or "array = { a, b };"

I know this naming might seem kind of crazy, but this is the naming stylelint uses for this check and it seems logical if you expect we'll have hundreds of tests and we want them ordered in some meaningful way