### PR TITLE
Parenthesis check tests

### DIFF
--- a/lib/Checks/BlockOpeningBraceSpaceBeforeCheck.vala
+++ b/lib/Checks/BlockOpeningBraceSpaceBeforeCheck.vala
@@ -33,6 +33,8 @@ public class ValaLint.Checks.BlockOpeningBraceSpaceBeforeCheck : Check {
             if (r.type == ParseType.Default) {
                 add_regex_mistake ("""[\w)=]\n\s*{""", _("Unexpected line break before \"{\""), r, ref mistake_list, 1);
                 add_regex_mistake ("""[\w)=]{""", _("Expected whitespace before \"{\""), r, ref mistake_list, 1);
+                // Check for a tab character or more than one whitespace character before the open parenthesis
+                add_regex_mistake ("""[\w)=](?:\t|\s{2,}){""", _("Expected single space before \"{\"}"), r, ref mistake_list, 1);
             }
         }
     }

--- a/lib/Checks/BlockOpeningBraceSpaceBeforeCheck.vala
+++ b/lib/Checks/BlockOpeningBraceSpaceBeforeCheck.vala
@@ -20,6 +20,10 @@
  */
 
 public class ValaLint.Checks.BlockOpeningBraceSpaceBeforeCheck : Check {
+    public BlockOpeningBraceSpaceBeforeCheck () {
+        single_mistake_in_line = true;
+    }
+
     public override string get_title () {
         return _("block-opening-brace-space-before");
     }

--- a/lib/Checks/BlockOpeningBraceSpaceBeforeCheck.vala
+++ b/lib/Checks/BlockOpeningBraceSpaceBeforeCheck.vala
@@ -34,7 +34,7 @@ public class ValaLint.Checks.BlockOpeningBraceSpaceBeforeCheck : Check {
                 add_regex_mistake ("""[\w)=]\n\s*{""", _("Unexpected line break before \"{\""), r, ref mistake_list, 1);
                 add_regex_mistake ("""[\w)=]{""", _("Expected whitespace before \"{\""), r, ref mistake_list, 1);
                 // Check for a tab character or more than one whitespace character before the open parenthesis
-                add_regex_mistake ("""[\w)=](?:\t|\s{2,}){""", _("Expected single space before \"{\"}"), r, ref mistake_list, 1);
+                add_regex_mistake ("""[\w)=](?:\t|\s{2,}){""", _("Expected single space before \"{\""), r, ref mistake_list, 1);
             }
         }
     }

--- a/test/UnitTest.vala
+++ b/test/UnitTest.vala
@@ -34,6 +34,11 @@ class UnitTest : GLib.Object {
         assert_pass (trailing_whitespace_check, "lorem ipsum");
         assert_warning (trailing_whitespace_check, "lorem ipsum ");
 
+        var block_parenthesis_check = new ValaLint.Checks.BlockOpeningBraceSpaceBeforeCheck ();
+        assert_pass (block_parenthesis_check, "test () {");
+        assert_warning (block_parenthesis_check, "test (){");
+        assert_warning (block_parenthesis_check, "test ()\n{");
+        assert_warning (block_parenthesis_check, "test ()   {");
         return 0;
     }
 
@@ -50,7 +55,7 @@ class UnitTest : GLib.Object {
         var parsed_result = parser.parse (input);
         var mistakes = new Gee.ArrayList<ValaLint.FormatMistake?> ();
         check.check (parsed_result, ref mistakes);
-        assert (mistakes.size == 1);
+        assert (mistakes.size > 0);
         if (char_pos > -1) {
             assert (mistakes[0].char_index == char_pos);
         }


### PR DESCRIPTION
Also add an extra type of mistake while we're there and make sure we only report a single warning for each line, or else you get one for having a newline and one for having more than one space.

Since we can return multiple mistakes in a line, it's probably also worth making our assertion checker catch cases where we return more than one warning (that still sounds like a warning to me). We don't need that yet, but it may catch someone out in future.