### PR TITLE
Restructure Check class to be more efficient

### DIFF
--- a/lib/Check.vala
+++ b/lib/Check.vala
@@ -22,6 +22,17 @@
 public abstract class ValaLint.Check : Object {
 
     /**
+     * A structure used to hold the regex patterns used to parse for errors
+     * within a check.
+     */
+    public struct RegexCheck {
+        public ParseType match_types;
+        public Regex pattern;
+        public string mistake_text;
+        public int offset;
+    }
+
+    /**
      * Property whether the check should allow multiple mistakes in a single line.
      */
     public bool single_mistake_in_line { get; construct; default = false; }
@@ -36,52 +47,76 @@ public abstract class ValaLint.Check : Object {
      */
     public string description { get; construct; }
 
+    private Gee.ArrayList<RegexCheck?> mistake_checkers = new Gee.ArrayList<RegexCheck?> ();
+
     /**
      * Checks a given parse result for formatting mistakes.
      *
      * @param parse_result The parsed string.
      * @param mistake_list The list new mistakes should be added to.
      */
-    public abstract void check (Gee.ArrayList<ParseResult?> parse_result, ref Gee.ArrayList<FormatMistake?> mistake_list);
+    public virtual void check (Gee.ArrayList<ParseResult?> parse_results, ref Gee.ArrayList<FormatMistake?> mistakes) {
+        foreach (var check in mistake_checkers) {
+            MatchInfo match_info;
+            foreach (var parse_result in parse_results) {
+                if (!(parse_result.type in check.match_types)) {
+                    continue;
+                }
+
+                try {
+                    check.pattern.match (parse_result.text, 0, out match_info);
+                    while (match_info.matches ()) {
+                        int pos_start;
+                        match_info.fetch_pos (0, out pos_start, null);
+
+                        int pos_mistake = pos_start + check.offset;
+                        int line_count = Utils.get_line_count (parse_result.text[0:pos_mistake]);
+                        int line_pos = parse_result.line_pos + line_count;
+                        int char_pos = Utils.get_char_index_in_line (parse_result.text, pos_mistake);
+                        if (line_count == 0) {
+                            char_pos += parse_result.char_pos;
+                        }
+
+                        /* If single_mistake_in_line is true, add only one mistake of the same check per line */
+                        if (!single_mistake_in_line ||
+                            (mistakes.is_empty || mistakes.last ().check != this || mistakes.last ().line_index < line_pos)) {
+                            mistakes.add ({ this, line_pos, char_pos, check.mistake_text });
+                        }
+
+
+                        match_info.next ();
+                    }
+                } catch (Error e) {
+                    critical ("Error while running regex against file: %s", e.message);
+                }
+            }
+        }
+    }
 
     /**
-     * Adds a mistake based on a regex pattern.
+     * Adds a type of mistake to match against based on a regex pattern.
      *
-     * @param pattern The regex pattern.
-     * @param mistake The mistake description.
-     * @param parse_result The current parse result element.
-     * @param mistakes The mistakes list.
+     * @param types Flags containing the parts of the file to check.
+     * @param pattern The regex pattern to try and match.
+     * @param mistake The warning text to display to the user
      * @param char_offset The offset between the mistake char position and the regex pattern start.
      */
-    protected void add_regex_mistake (string pattern, string mistake, ParseResult parse_result, ref Gee.ArrayList<FormatMistake?> mistakes, int char_offset = 0) {
-
-        MatchInfo match_info;
+    protected void add_regex_check (ParseType types, string pattern, string mistake, int char_offset = 0) {
+        Regex regex;
         try {
-            var regex = new Regex (pattern);
-            regex.match (parse_result.text, 0, out match_info);
-            while (match_info.matches ()) {
-                int pos_start, pos_end;
-                match_info.fetch_pos (0, out pos_start, out pos_end);
-
-                int pos_mistake = pos_start + char_offset;
-                int line_count = Utils.get_line_count (parse_result.text[0:pos_mistake]);
-                int line_pos = parse_result.line_pos + line_count;
-                int char_pos = Utils.get_char_index_in_line (parse_result.text, pos_mistake);
-                if (line_count == 0) {
-                    char_pos += parse_result.char_pos;
-                }
-
-                /* If single_mistake_in_line is true, add only one mistake of the same check per line */
-                if (!single_mistake_in_line ||
-                    (mistakes.is_empty || mistakes.last ().check != this || mistakes.last ().line_index < line_pos)) {
-                    mistakes.add ({ this, line_pos, char_pos, mistake });
-                }
-
-
-                match_info.next ();
-            }
-        } catch {
-            critical ("%s is not a valid Regex", pattern);
+            regex = new Regex (pattern);
+        } catch (Error e) {
+            critical ("Error constructing regex \"%s\" for check: %s", pattern, e.message);
+            return;
         }
+
+        var check = RegexCheck () {
+            match_types = types,
+            pattern = regex,
+            mistake_text = mistake,
+            offset = char_offset
+        };
+
+        mistake_checkers.add (check);
     }
 }

--- a/lib/Checks/BlockOpeningBraceSpaceBeforeCheck.vala
+++ b/lib/Checks/BlockOpeningBraceSpaceBeforeCheck.vala
@@ -41,6 +41,7 @@ public class ValaLint.Checks.BlockOpeningBraceSpaceBeforeCheck : Check {
             1
         );
 
+        // Check for a tab character or more than one whitespace character before the open parenthesis
         add_regex_check (
             ParseType.Default,
             """[\w)=](?:\t|\s{2,}){""",

--- a/lib/Checks/BlockOpeningBraceSpaceBeforeCheck.vala
+++ b/lib/Checks/BlockOpeningBraceSpaceBeforeCheck.vala
@@ -25,14 +25,19 @@ public class ValaLint.Checks.BlockOpeningBraceSpaceBeforeCheck : Check {
             title: _("block-opening-brace-space-before"),
             description: _("Checks for correct use of opening braces")
         );
-    }
 
-    public override void check (Gee.ArrayList<ParseResult? > parse_result, ref Gee.ArrayList<FormatMistake? > mistake_list) {
-        foreach (ParseResult r in parse_result) {
-            if (r.type == ParseType.Default) {
-                add_regex_mistake ("""[\w)=]\n\s*{""", _("Unexpected line break before \"{\""), r, ref mistake_list, 1);
-                add_regex_mistake ("""[\w)=]{""", _("Expected whitespace before \"{\""), r, ref mistake_list, 1);
-            }
-        }
+        add_regex_check (
+            ParseType.Default,
+            """[\w)=]\n\s*{""",
+            _("Unexpected line break before \"{\""),
+            1
+        );
+
+        add_regex_check (
+            ParseType.Default,
+            """[\w)=]{""",
+            _("Expected whitespace before \"{\""),
+            1
+        );
     }
 }

--- a/lib/Checks/EllipsisCheck.vala
+++ b/lib/Checks/EllipsisCheck.vala
@@ -23,13 +23,11 @@ public class ValaLint.Checks.EllipsisCheck : Check {
             title: _("ellipsis"),
             description: _("Checks for ellipsis character instead of three periods")
         );
-    }
 
-    public override void check (Gee.ArrayList<ParseResult?> parse_result, ref Gee.ArrayList<FormatMistake? > mistake_list) {
-        foreach (ParseResult r in parse_result) {
-            if (r.type == ParseType.String) {
-                add_regex_mistake ("""\.\.\.""", _("Expected ellipsis instead of three periods"), r, ref mistake_list);
-            }
-        }
+        add_regex_check (
+            ParseType.String,
+            """\.\.\.""",
+            _("Expected ellipsis instead of three periods")
+        );
     }
 }

--- a/lib/Checks/TabCheck.vala
+++ b/lib/Checks/TabCheck.vala
@@ -24,13 +24,11 @@ public class ValaLint.Checks.TabCheck : Check {
             title: _("use-of-tabs"),
             description: _("Checks for tabs instead of spaces")
         );
-    }
 
-    public override void check (Gee.ArrayList<ParseResult? > parse_result, ref Gee.ArrayList<FormatMistake? > mistake_list) {
-        foreach (ParseResult r in parse_result) {
-            if (r.type == ParseType.Default || r.type == ParseType.Comment) {
-                add_regex_mistake ("""\t""", _("Expected spaces instead of tabs"), r, ref mistake_list, 0);
-            }
-        }
+        add_regex_check (
+            ParseType.Default | ParseType.Comment,
+            """\t""",
+            _("Expected spaces instead of tabs")
+        );
     }
 }

--- a/lib/Checks/TrailingWhitespaceCheck.vala
+++ b/lib/Checks/TrailingWhitespaceCheck.vala
@@ -25,19 +25,17 @@ public class ValaLint.Checks.TrailingWhitespaceCheck : Check {
             title: _("trailing-whitespace"),
             description:_("Checks for whitespaces at the end of lines")
         );
-    }
 
-    public override void check (Gee.ArrayList<ParseResult? > parse_result, ref Gee.ArrayList<FormatMistake? > mistake_list) {
-        foreach (ParseResult r in parse_result) {
-            if (r.type == ParseType.Default) {
-                add_regex_mistake ("""\h\n""", _("Unexpected whitespace at end of line"), r, ref mistake_list);
-            }
-        }
+        add_regex_check (
+            ParseType.Default,
+            """\h\n""",
+            _("Unexpected whitespace at end of line")
+        );
 
-        // Check for whitespace at last line
-        ParseResult r_last = parse_result.last ();
-        if (r_last.type == ParseType.Default) {
-            add_regex_mistake ("""\h$""", _("Unexpected whitespace at end of last line"), r_last, ref mistake_list);
-        }
+        add_regex_check (
+            ParseType.Default,
+            """\h$""",
+            _("Unexpected whitespace at end of last line")
+        );
     }
 }

--- a/lib/ParseResult.vala
+++ b/lib/ParseResult.vala
@@ -17,6 +17,7 @@
  * Boston, MA 02110-1301 USA.
  */
 
+[Flags]
 public enum ParseType {
     Default,
     Comment,


### PR DESCRIPTION
Previously the regex object was being created many times, which was probably inefficient.

We should hold an array of the types of check we want to do in each check object, and just run that against the parsed file.