### PR TITLE
Add Always Use Braces Check

### DIFF
--- a/lib/Checks/AlwaysUseBracesCheck.vala
+++ b/lib/Checks/AlwaysUseBracesCheck.vala
@@ -27,7 +27,7 @@ public class ValaLint.Checks.AlwaysUseBracesCheck : Check {
 
     public override void check (Gee.ArrayList<ParseResult?> parse_result, ref Gee.ArrayList<FormatMistake?> mistake_list) {
         foreach (ParseResult r in parse_result) {
-            if (r.type == ParseType.Default) {
+            if (r.type == ParseType.DEFAULT) {
                 add_regex_mistake ("""\)\s*\n""", _("Expected an opening brace"), r, ref mistake_list, 1);
                 add_regex_mistake ("""else\s*\n""", _("Expected an opening brace"), r, ref mistake_list, 4);
                 add_regex_mistake ("""\n\s*else""", _("Expected a closing brace"), r, ref mistake_list, -4);

--- a/lib/Checks/AlwaysUseBracesCheck.vala
+++ b/lib/Checks/AlwaysUseBracesCheck.vala
@@ -26,13 +26,11 @@ public class ValaLint.Checks.AlwaysUseBracesCheck : Check {
     }
 
     public override void check (Gee.ArrayList<ParseResult?> parse_result, ref Gee.ArrayList<FormatMistake?> mistake_list) {
-        string message = _("Expected brace in this line");
-
         foreach (ParseResult r in parse_result) {
             if (r.type == ParseType.Default) {
-                add_regex_mistake ("""\)\s*\n""", message, r, ref mistake_list, 1);
-                add_regex_mistake ("""else\s*\n""", message, r, ref mistake_list, 4);
-                add_regex_mistake ("""\n\s*else""", message, r, ref mistake_list, -4);
+                add_regex_mistake ("""\)\s*\n""", _("Expected an opening brace"), r, ref mistake_list, 1);
+                add_regex_mistake ("""else\s*\n""", _("Expected an opening brace"), r, ref mistake_list, 4);
+                add_regex_mistake ("""\n\s*else""", _("Expected a closing brace"), r, ref mistake_list, -4);
             }
         }
     }

--- a/lib/Checks/AlwaysUseBracesCheck.vala
+++ b/lib/Checks/AlwaysUseBracesCheck.vala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2018 elementary LLC. (https://github.com/elementary/vala-lint)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ */
+
+public class ValaLint.Checks.AlwaysUseBracesCheck : Check {
+    public AlwaysUseBracesCheck () {
+        Object (
+            title: _("always-use-braces"),
+            description: _("Checks for braces")
+        );
+    }
+
+    public override void check (Gee.ArrayList<ParseResult?> parse_result, ref Gee.ArrayList<FormatMistake?> mistake_list) {
+        string message = _("Expected brace in this line");
+
+        foreach (ParseResult r in parse_result) {
+            if (r.type == ParseType.Default) {
+                add_regex_mistake ("""\)\s*\n""", message, r, ref mistake_list, 1);
+                add_regex_mistake ("""else\s*\n""", message, r, ref mistake_list, 4);
+                add_regex_mistake ("""\n\s*else""", message, r, ref mistake_list, -4);
+            }
+        }
+    }
+}

--- a/lib/Linter.vala
+++ b/lib/Linter.vala
@@ -24,6 +24,7 @@ public class ValaLint.Linter : Object {
 
     public Linter () {
         enabled_checks = new Gee.ArrayList<Check> ();
+        enabled_checks.add (new Checks.AlwaysUseBracesCheck ());
         enabled_checks.add (new Checks.BlockOpeningBraceSpaceBeforeCheck ());
         enabled_checks.add (new Checks.EllipsisCheck ());
         enabled_checks.add (new Checks.TabCheck ());

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -5,6 +5,7 @@ vala_linter_files = files(
     'Parser.vala',
     'ParseResult.vala',
     'Utils.vala',
+    'Checks/AlwaysUseBracesCheck.vala',
     'Checks/BlockOpeningBraceSpaceBeforeCheck.vala',
     'Checks/EllipsisCheck.vala',
     'Checks/TabCheck.vala',

--- a/test/UnitTest.vala
+++ b/test/UnitTest.vala
@@ -21,6 +21,11 @@ class UnitTest : GLib.Object {
 
     public static int main (string[] args) {
 
+        var always_use_brace_check = new ValaLint.Checks.AlwaysUseBracesCheck ();
+        assert_pass (always_use_brace_check, "if (a == \"{\") { return 2; }");
+        assert_warning (always_use_brace_check, "while (a == 3) \n a = 2;");
+        assert_warning (always_use_brace_check, "else \n a = 2;");
+
         var ellipsis_check = new ValaLint.Checks.EllipsisCheck ();
         assert_pass (ellipsis_check, "lorem ipsum");
         assert_pass (ellipsis_check, "lorem ipsum...");


### PR DESCRIPTION
This checks for missing braces, e.g. in `if (...)` statements.