### PR TITLE
Add Vala AST and Naming Checks

### DIFF
--- a/lib/Check.vala
+++ b/lib/Check.vala
@@ -53,7 +53,7 @@ public abstract class ValaLint.Check : Object {
      * @param mistakes The mistakes list.
      * @param char_offset The offset between the mistake char position and the regex pattern start.
      */
-    protected void add_regex_mistake (string pattern, string mistake, ParseResult parse_result, ref Gee.ArrayList<FormatMistake?> mistakes, int char_offset = 0) {
+    protected void add_regex_mistake (string pattern, string mistake, ParseResult parse_result, ref Gee.ArrayList<FormatMistake?> mistakes, int char_offset = 0, bool return_after_mistake = false) {
 
         MatchInfo match_info;
         try {
@@ -76,7 +76,6 @@ public abstract class ValaLint.Check : Object {
                     (mistakes.is_empty || mistakes.last ().check != this || mistakes.last ().line_index < line_pos)) {
                     mistakes.add ({ this, line_pos, char_pos, mistake });
                 }
-
 
                 match_info.next ();
             }

--- a/lib/Checks/NamingAllCapsCheck.vala
+++ b/lib/Checks/NamingAllCapsCheck.vala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2018 elementary LLC. (https://github.com/elementary/vala-lint)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ */
+
+public class ValaLint.Checks.NamingAllCapsCheck : Check {
+    public NamingAllCapsCheck () {
+        Object (
+            title: _("naming-convention"),
+            description: _("Checks for the all caps naming convention")
+        );
+    }
+
+    public override void check (Gee.ArrayList<ParseResult?> parse_result, ref Gee.ArrayList<FormatMistake?> mistake_list) {
+        foreach (ParseResult r in parse_result) {
+            add_regex_mistake ("""[a-z-]""", "Use ALL_CAPS_CONVENTION", r, ref mistake_list, 0, true);
+        }
+    }
+}

--- a/lib/Checks/NamingCamelCaseCheck.vala
+++ b/lib/Checks/NamingCamelCaseCheck.vala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2018 elementary LLC. (https://github.com/elementary/vala-lint)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ */
+
+public class ValaLint.Checks.NamingCamelCaseCheck : Check {
+    public NamingCamelCaseCheck () {
+        Object (
+            title: _("naming-convention"),
+            description: _("Checks for the camel case naming convention")
+        );
+    }
+
+    public override void check (Gee.ArrayList<ParseResult?> parse_result, ref Gee.ArrayList<FormatMistake?> mistake_list) {
+        foreach (ParseResult r in parse_result) {
+            add_regex_mistake ("""(^[a-z]|_)""", "Use CamelCaseConvention", r, ref mistake_list, 0, true);
+        }
+    }
+}

--- a/lib/Checks/NamingUnderscoreCheck.vala
+++ b/lib/Checks/NamingUnderscoreCheck.vala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2018 elementary LLC. (https://github.com/elementary/vala-lint)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ */
+
+public class ValaLint.Checks.NamingUnderscoreCheck : Check {
+    public NamingUnderscoreCheck () {
+        Object (
+            title: _("naming-convention"),
+            description: _("Checks for the underscore naming convention")
+        );
+    }
+
+    public override void check (Gee.ArrayList<ParseResult?> parse_result, ref Gee.ArrayList<FormatMistake?> mistake_list) {
+        foreach (ParseResult r in parse_result) {
+            add_regex_mistake ("""[A-Z-]""", "Use underscore_convention", r, ref mistake_list, 0, true);
+        }
+    }
+}

--- a/lib/Linter.vala
+++ b/lib/Linter.vala
@@ -82,18 +82,6 @@ public class ValaLint.Linter : Object {
             check.check (parse_result, ref mistake_list);
         }
 
-        /* var channel = new IOChannel.file (file.get_path (), "r");
-        string text;
-        size_t length;
-        channel.read_to_end (out text, out length);
-
-        var parser = new ValaLint.Parser ();
-        Gee.ArrayList<ParseResult?> parse_result = parser.parse (text);
-
-        foreach (Check check in global_checks) {
-            check.check (parse_result, ref mistake_list);
-        } */
-
         mistake_list.sort ((a, b) => {
             if (a.line_index == b.line_index) {
                 return a.char_index - b.char_index;

--- a/lib/ValaReporter.vala
+++ b/lib/ValaReporter.vala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018 elementary LLC. (https://github.com/elementary/vala-lint)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ */
+
+class ValaLint.Reporter : Vala.Report {
+    Gee.ArrayList<FormatMistake?> mistake_list;
+
+    /* If we want, the Vala Reporter class could add its own warnings to our mistake_list */
+    public Reporter (Gee.ArrayList<FormatMistake?> mistake_list) {
+        this.mistake_list = mistake_list;
+    }
+
+    public override void note (Vala.SourceReference? reference, string message) { }
+
+    public override void depr (Vala.SourceReference? reference, string message) { }
+
+    public override void warn (Vala.SourceReference? reference, string message) { }
+
+    public override void err (Vala.SourceReference? reference, string message) { }
+}

--- a/lib/ValaVisitor.vala
+++ b/lib/ValaVisitor.vala
@@ -24,7 +24,6 @@ class ValaLint.Visitor : CodeVisitor {
 
     public Gee.ArrayList<Check> checks { get; set; }
 
-    // public Checks.EllipsisCheck ellipsis_check;
     public Checks.NamingAllCapsCheck naming_all_caps_check;
     public Checks.NamingCamelCaseCheck naming_camel_case_check;
     public Checks.NamingUnderscoreCheck naming_underscore_check;

--- a/lib/ValaVisitor.vala
+++ b/lib/ValaVisitor.vala
@@ -1,0 +1,373 @@
+/*
+ * Copyright (c) 2018 elementary LLC. (https://github.com/elementary/vala-lint)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ */
+
+using Vala;
+
+class ValaLint.Visitor : CodeVisitor {
+    public Gee.ArrayList<FormatMistake?> mistake_list;
+
+    public Gee.ArrayList<Check> checks { get; set; }
+
+    // public Checks.EllipsisCheck ellipsis_check;
+    public Checks.NamingAllCapsCheck naming_all_caps_check;
+    public Checks.NamingCamelCaseCheck naming_camel_case_check;
+    public Checks.NamingUnderscoreCheck naming_underscore_check;
+
+    public void set_mistake_list (Gee.ArrayList<FormatMistake?> mistake_list) {
+        this.mistake_list = mistake_list;
+    }
+
+    public override void visit_source_file (SourceFile sf) {
+        sf.accept_children (this);
+    }
+
+    public override void visit_namespace (Namespace ns) {
+        naming_camel_case_check.check (string_parsed (ns.name, ns.source_reference), ref mistake_list);
+        ns.accept_children (this);
+    }
+
+    public override void visit_class (Class cl) {
+        naming_camel_case_check.check (string_parsed (cl.name, cl.source_reference), ref mistake_list);
+        cl.accept_children (this);
+    }
+
+    public override void visit_struct (Struct st) {
+        naming_camel_case_check.check (string_parsed (st.name, st.source_reference), ref mistake_list);
+        st.accept_children (this);
+    }
+
+    public override void visit_interface (Interface iface) {
+        naming_camel_case_check.check (string_parsed (iface.name, iface.source_reference), ref mistake_list);
+        iface.accept_children (this);
+    }
+
+    public override void visit_enum (Enum en) {
+        naming_camel_case_check.check (string_parsed (en.name, en.source_reference), ref mistake_list);
+        en.accept_children (this);
+    }
+
+    public override void visit_enum_value (Vala.EnumValue ev) {
+        naming_all_caps_check.check (string_parsed (ev.name, ev.source_reference), ref mistake_list);
+        ev.accept_children (this);
+    }
+
+    public override void visit_error_domain (ErrorDomain edomain) {
+        edomain.accept_children (this);
+    }
+
+    public override void visit_error_code (ErrorCode ecode) {
+        ecode.accept_children (this);
+    }
+
+    public override void visit_delegate (Delegate d) {
+        d.accept_children (this);
+    }
+
+    public override void visit_constant (Constant c) {
+        naming_all_caps_check.check (string_parsed (c.name, c.source_reference), ref mistake_list);
+        c.accept_children (this);
+    }
+
+    public override void visit_field (Field f) {
+        naming_underscore_check.check (string_parsed (f.name, f.source_reference), ref mistake_list);
+        f.accept_children (this);
+    }
+
+    public override void visit_method (Method m) {
+        naming_underscore_check.check (string_parsed (m.name, m.source_reference), ref mistake_list);
+        m.accept_children (this);
+    }
+
+    public override void visit_creation_method (CreationMethod m) {
+        m.accept_children (this);
+    }
+
+    public override void visit_formal_parameter (Vala.Parameter p) {
+        naming_underscore_check.check (string_parsed (p.name, p.source_reference), ref mistake_list);
+        p.accept_children (this);
+    }
+
+    public override void visit_property (Property prop) {
+        prop.accept_children (this);
+    }
+
+    public override void visit_property_accessor (PropertyAccessor acc) {
+        acc.accept_children (this);
+    }
+
+    public override void visit_signal (Vala.Signal sig) {
+        sig.accept_children (this);
+    }
+
+    public override void visit_constructor (Constructor c) {
+        c.accept_children (this);
+    }
+
+    public override void visit_destructor (Destructor d) {
+        d.accept_children (this);
+    }
+
+    public override void visit_type_parameter (TypeParameter p) {
+        p.accept_children (this);
+    }
+
+    public override void visit_using_directive (UsingDirective ns) {
+        ns.accept_children (this);
+    }
+
+    public override void visit_data_type (DataType type) {
+        type.accept_children (this);
+    }
+
+    public override void visit_block (Block b) {
+        b.accept_children (this);
+    }
+
+    public override void visit_empty_statement (EmptyStatement stmt) {
+    }
+
+    public override void visit_declaration_statement (DeclarationStatement stmt) {
+        stmt.accept_children (this);
+    }
+
+    public override void visit_local_variable (LocalVariable local) {
+        local.accept_children (this);
+    }
+
+    public override void visit_initializer_list (InitializerList list) {
+        list.accept_children (this);
+    }
+
+    public override void visit_expression_statement (ExpressionStatement stmt) {
+        stmt.accept_children (this);
+    }
+
+    public override void visit_if_statement (IfStatement stmt) {
+        stmt.accept_children (this);
+    }
+
+    public override void visit_switch_statement (SwitchStatement stmt) {
+        stmt.accept_children (this);
+    }
+
+    public override void visit_switch_section (SwitchSection section) {
+        section.accept_children (this);
+    }
+
+    public override void visit_switch_label (SwitchLabel label) {
+        label.accept_children (this);
+    }
+
+    public override void visit_loop (Loop stmt) {
+        stmt.accept_children (this);
+    }
+
+    public override void visit_while_statement (WhileStatement stmt) {
+        stmt.accept_children (this);
+    }
+
+    public override void visit_do_statement (DoStatement stmt) {
+        stmt.accept_children (this);
+    }
+
+    public override void visit_for_statement (ForStatement stmt) {
+        stmt.accept_children (this);
+    }
+
+    public override void visit_foreach_statement (ForeachStatement stmt) {
+        stmt.accept_children (this);
+    }
+
+    public override void visit_break_statement (BreakStatement stmt) {
+        stmt.accept_children (this);
+    }
+
+    public override void visit_continue_statement (ContinueStatement stmt) {
+        stmt.accept_children (this);
+    }
+
+    public override void visit_return_statement (ReturnStatement stmt) {
+        stmt.accept_children (this);
+    }
+
+    public override void visit_yield_statement (YieldStatement y) {
+        y.accept_children (this);
+    }
+
+    public override void visit_throw_statement (ThrowStatement stmt) {
+        stmt.accept_children (this);
+    }
+
+    public override void visit_try_statement (TryStatement stmt) {
+        stmt.accept_children (this);
+    }
+
+    public override void visit_catch_clause (CatchClause clause) {
+        clause.accept_children (this);
+    }
+
+    public override void visit_lock_statement (LockStatement stmt) {
+        stmt.accept_children (this);
+    }
+
+    public override void visit_unlock_statement (UnlockStatement stmt) {
+        stmt.accept_children (this);
+    }
+
+    public override void visit_delete_statement (DeleteStatement stmt) {
+        stmt.accept_children (this);
+    }
+
+    public override void visit_expression (Expression expr) {
+        expr.accept_children (this);
+    }
+
+    public override void visit_array_creation_expression (ArrayCreationExpression expr) {
+        expr.accept_children (this);
+    }
+
+    public override void visit_boolean_literal (BooleanLiteral lit) {
+        lit.accept_children (this);
+    }
+
+    public override void visit_character_literal (CharacterLiteral lit) {
+        lit.accept_children (this);
+    }
+
+    public override void visit_integer_literal (IntegerLiteral lit) {
+        lit.accept_children (this);
+    }
+
+    public override void visit_real_literal (RealLiteral lit) {
+        lit.accept_children (this);
+    }
+
+    public override void visit_regex_literal (RegexLiteral lit) {
+        lit.accept_children (this);
+    }
+
+    public override void visit_string_literal (StringLiteral lit) {
+        // TODO Move ellipsis check here
+        // ellipsis_check.check (string_parsed (lit.value, lit.source_reference, ParseType.STRING), ref mistake_list);
+        lit.accept_children (this);
+    }
+
+    public override void visit_template (Template tmpl) {
+        tmpl.accept_children (this);
+    }
+
+    public override void visit_tuple (Tuple tuple) {
+        tuple.accept_children (this);
+    }
+
+    public override void visit_null_literal (NullLiteral lit) {
+        lit.accept_children (this);
+    }
+
+    public override void visit_member_access (MemberAccess expr) {
+        expr.accept_children (this);
+    }
+
+    public override void visit_method_call (MethodCall expr) {
+        expr.accept_children (this);
+    }
+
+    public override void visit_element_access (ElementAccess expr) {
+        expr.accept_children (this);
+	}
+
+    public override void visit_slice_expression (SliceExpression expr) {
+        expr.accept_children (this);
+    }
+
+    public override void visit_base_access (BaseAccess expr) {
+        expr.accept_children (this);
+	}
+
+    public override void visit_postfix_expression (PostfixExpression expr) {
+        expr.accept_children (this);
+	}
+
+    public override void visit_object_creation_expression (ObjectCreationExpression expr) {
+        expr.accept_children (this);
+	}
+
+    public override void visit_sizeof_expression (SizeofExpression expr) {
+        expr.accept_children (this);
+	}
+
+    public override void visit_typeof_expression (TypeofExpression expr) {
+        expr.accept_children (this);
+	}
+
+    public override void visit_unary_expression (UnaryExpression expr) {
+        expr.accept_children (this);
+	}
+
+    public override void visit_cast_expression (CastExpression expr) {
+        expr.accept_children (this);
+	}
+
+    public override void visit_named_argument (NamedArgument expr) {
+        expr.accept_children (this);
+    }
+
+    public override void visit_pointer_indirection (PointerIndirection expr) {
+        expr.accept_children (this);
+	}
+
+    public override void visit_addressof_expression (AddressofExpression expr) {
+        expr.accept_children (this);
+	}
+
+    public override void visit_reference_transfer_expression (ReferenceTransferExpression expr) {
+        expr.accept_children (this);
+	}
+
+    public override void visit_binary_expression (BinaryExpression expr) {
+        expr.accept_children (this);
+	}
+
+    public override void visit_type_check (TypeCheck expr) {
+        expr.accept_children (this);
+	}
+
+    public override void visit_conditional_expression (ConditionalExpression expr) {
+        expr.accept_children (this);
+	}
+
+    public override void visit_lambda_expression (LambdaExpression expr) {
+        expr.accept_children (this);
+    }
+
+    public override void visit_assignment (Assignment a) {
+        a.accept_children (this);
+    }
+
+    public override void visit_end_full_expression (Expression expr) {
+        expr.accept_children (this);
+    }
+
+    private static Gee.ArrayList<ParseResult?> string_parsed (string text, SourceReference source_ref, ParseType type = ParseType.Default) {
+        var parsed = new Gee.ArrayList<ParseResult?> ();
+        ParseResult result = { text, type, source_ref.begin.line, source_ref.begin.column };
+        parsed.add (result);
+        return parsed;
+    }
+}

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -5,15 +5,21 @@ vala_linter_files = files(
     'Parser.vala',
     'ParseResult.vala',
     'Utils.vala',
+    'ValaReporter.vala',
+    'ValaVisitor.vala',
     'Checks/BlockOpeningBraceSpaceBeforeCheck.vala',
     'Checks/EllipsisCheck.vala',
+    'Checks/NamingAllCapsCheck.vala',
+    'Checks/NamingCamelCaseCheck.vala',
+    'Checks/NamingUnderscoreCheck.vala',
     'Checks/TabCheck.vala',
     'Checks/TrailingWhitespaceCheck.vala',
 )
 
 vala_linter_deps = [
     gee_dep,
-    gio_dep
+    gio_dep,
+    libvala_dep,
 ]
 
 vala_linter_library = shared_library(

--- a/meson.build
+++ b/meson.build
@@ -7,6 +7,7 @@ add_project_arguments('-DGETTEXT_PACKAGE="@0@"'.format(meson.project_name()), la
 
 gee_dep = dependency('gee-0.8')
 gio_dep = dependency('gio-2.0')
+libvala_dep = dependency('libvala-0.40')
 posix_dep = meson.get_compiler('vala').find_library('posix')
 
 subdir('lib')

--- a/test/UnitTest.vala
+++ b/test/UnitTest.vala
@@ -26,6 +26,29 @@ class UnitTest : GLib.Object {
         assert_pass (ellipsis_check, "lorem ipsum...");
         assert_warning (ellipsis_check, "lorem ipsum\"...\"");
 
+        var naming_all_caps_check = new ValaLint.Checks.NamingAllCapsCheck ();
+        assert_pass (naming_all_caps_check, "LOREM");
+        assert_pass (naming_all_caps_check, "LOREM_IPSUM");
+        assert_warning (naming_all_caps_check, "lOREM");
+        assert_warning (naming_all_caps_check, "LOREm");
+        assert_warning (naming_all_caps_check, "LOREM-IPSUM");
+
+        var naming_camel_case_check = new ValaLint.Checks.NamingCamelCaseCheck ();
+        assert_pass (naming_camel_case_check, "Lorem");
+        assert_pass (naming_camel_case_check, "LoremIpsum");
+        assert_pass (naming_camel_case_check, "HTTPConnection");
+        assert_warning (naming_camel_case_check, "lorem");
+        assert_warning (naming_camel_case_check, "loremIpsum");
+        assert_warning (naming_camel_case_check, "lorem_ipsum");
+        assert_warning (naming_camel_case_check, "lorem-ipsum");
+
+        var naming_underscore_check = new ValaLint.Checks.NamingUnderscoreCheck ();
+        assert_pass (naming_underscore_check, "lorem");
+        assert_pass (naming_underscore_check, "lorem_ipsum");
+        assert_warning (naming_underscore_check, "Lorem");
+        assert_warning (naming_underscore_check, "Lorem_Ipsum");
+        assert_warning (naming_underscore_check, "lorem_IPsum");
+
         var tab_check = new ValaLint.Checks.TabCheck ();
         assert_pass (tab_check, "lorem ipsum");
         assert_warning (tab_check, "lorem	ipsum");


### PR DESCRIPTION
This PR introduces the libvala parser to build an AST (fixes #23). Then, checks can either run on our own parser (to differentiate between strings, comments and code) or on the real abstract syntax tree. I've added checks for our naming conventions.

We could also add vala warnings or errors to our linter.