### PR TITLE
Code style: Fix line length warnings

### DIFF
--- a/lib/Checks/BlockOpeningBraceSpaceBeforeCheck.vala
+++ b/lib/Checks/BlockOpeningBraceSpaceBeforeCheck.vala
@@ -28,13 +28,15 @@ public class ValaLint.Checks.BlockOpeningBraceSpaceBeforeCheck : Check {
         );
     }
 
-    public override void check (Vala.ArrayList<ParseResult?> parse_result, ref Vala.ArrayList<FormatMistake?> mistake_list) {
+    public override void check (Vala.ArrayList<ParseResult?> parse_result,
+                                ref Vala.ArrayList<FormatMistake?> mistake_list) {
         foreach (ParseResult r in parse_result) {
             if (r.type == ParseType.DEFAULT) {
                 add_regex_mistake ("""[\w)=]\n\s*{""", _("Unexpected line break before \"{\""), r, ref mistake_list, 1);
                 add_regex_mistake ("""[\w)=]{""", _("Expected whitespace before \"{\""), r, ref mistake_list, 1);
                 // Check for a tab character or more than one whitespace character before the open parenthesis
-                add_regex_mistake ("""[\w)=](?:\t|\s{2,}){""", _("Expected single space before \"{\""), r, ref mistake_list, 1);
+                add_regex_mistake ("""[\w)=](?:\t|\s{2,}){""", _("Expected single space before \"{\""), r,
+                                   ref mistake_list, 1);
             }
         }
     }

--- a/lib/Checks/DoubleSpacesCheck.vala
+++ b/lib/Checks/DoubleSpacesCheck.vala
@@ -25,11 +25,13 @@ public class ValaLint.Checks.DoubleSpacesCheck : Check {
         );
     }
 
-    public override void check (Vala.ArrayList<ParseResult?> parse_result, ref Vala.ArrayList<FormatMistake?> mistake_list) {
+    public override void check (Vala.ArrayList<ParseResult?> parse_result,
+                                ref Vala.ArrayList<FormatMistake?> mistake_list) {
         for (int i = 0; i < parse_result.size; i++) {
             ParseResult r = parse_result[i];
             if (r.type == ParseType.DEFAULT) {
-                bool next_parse_type_is_comment = (i + 1 < parse_result.size && parse_result[i + 1].type == ParseType.COMMENT);
+                bool next_parse_type_is_comment = (i + 1 < parse_result.size
+                                                   && parse_result[i + 1].type == ParseType.COMMENT);
 
                 /* Should not end with spaces pattern */
                 string no_spaces_pattern = next_parse_type_is_comment ? """(?!(?:$| ))""" : "";

--- a/lib/Checks/EllipsisCheck.vala
+++ b/lib/Checks/EllipsisCheck.vala
@@ -25,7 +25,8 @@ public class ValaLint.Checks.EllipsisCheck : Check {
         );
     }
 
-    public override void check (Vala.ArrayList<ParseResult?> parse_result, ref Vala.ArrayList<FormatMistake?> mistake_list) {
+    public override void check (Vala.ArrayList<ParseResult?> parse_result,
+                                ref Vala.ArrayList<FormatMistake?> mistake_list) {
         foreach (ParseResult r in parse_result) {
             if (r.type == ParseType.STRING) {
                 add_regex_mistake ("""\.\.\.""", _("Expected ellipsis instead of three periods"), r, ref mistake_list);

--- a/lib/Checks/LineLengthCheck.vala
+++ b/lib/Checks/LineLengthCheck.vala
@@ -19,6 +19,7 @@
 
 public class ValaLint.Checks.LineLengthCheck : Check {
     const int MAXIMUM_CHARACTERS = 120;
+    const string MESSAGE = @"Line exceeds limit of %d characters (currently %d characters)";
 
     public LineLengthCheck () {
         Object (
@@ -27,7 +28,8 @@ public class ValaLint.Checks.LineLengthCheck : Check {
         );
     }
 
-    public override void check (Vala.ArrayList<ParseResult?> parse_result, ref Vala.ArrayList<FormatMistake?> mistake_list) {
+    public override void check (Vala.ArrayList<ParseResult?> parse_result,
+                                ref Vala.ArrayList<FormatMistake?> mistake_list) {
         string input = "";
         foreach (ParseResult r in parse_result) {
             input += r.text;
@@ -37,8 +39,8 @@ public class ValaLint.Checks.LineLengthCheck : Check {
         foreach (string line in input.split ("\n")) {
             if (line.char_count () > MAXIMUM_CHARACTERS) {
                 int line_length = line.char_count ();
-                string message = @"Line exceeds limit of $MAXIMUM_CHARACTERS characters (currently $line_length characters)";
-                mistake_list.add ({ this, line_counter, MAXIMUM_CHARACTERS, message });
+                string formatted_message = MESSAGE.printf (MAXIMUM_CHARACTERS, line_length);
+                mistake_list.add ({ this, line_counter, MAXIMUM_CHARACTERS, formatted_message });
             }
             line_counter += 1;
         }

--- a/lib/Checks/NamingAllCapsCheck.vala
+++ b/lib/Checks/NamingAllCapsCheck.vala
@@ -25,9 +25,11 @@ public class ValaLint.Checks.NamingAllCapsCheck : Check {
         );
     }
 
-    public override void check (Vala.ArrayList<ParseResult?> parse_result, ref Vala.ArrayList<FormatMistake?> mistake_list) {
+    public override void check (Vala.ArrayList<ParseResult?> parse_result,
+                                ref Vala.ArrayList<FormatMistake?> mistake_list) {
         foreach (ParseResult r in parse_result) {
-            add_regex_mistake ("""[a-z-]""", _("Expected variable name in ALL_CAPS_CONVENTION"), r, ref mistake_list, 0, true);
+            add_regex_mistake ("""[a-z-]""", _("Expected variable name in ALL_CAPS_CONVENTION"), r,
+                               ref mistake_list, 0, true);
         }
     }
 }

--- a/lib/Checks/NamingCamelCaseCheck.vala
+++ b/lib/Checks/NamingCamelCaseCheck.vala
@@ -25,9 +25,11 @@ public class ValaLint.Checks.NamingCamelCaseCheck : Check {
         );
     }
 
-    public override void check (Vala.ArrayList<ParseResult?> parse_result, ref Vala.ArrayList<FormatMistake?> mistake_list) {
+    public override void check (Vala.ArrayList<ParseResult?> parse_result,
+                                ref Vala.ArrayList<FormatMistake?> mistake_list) {
         foreach (ParseResult r in parse_result) {
-            add_regex_mistake ("""(^[a-z]|_)""", _("Expected variable name in CamelCaseConvention"), r, ref mistake_list, 0, true);
+            add_regex_mistake ("""(^[a-z]|_)""", _("Expected variable name in CamelCaseConvention"), r,
+                               ref mistake_list, 0, true);
         }
     }
 }

--- a/lib/Checks/NamingUnderscoreCheck.vala
+++ b/lib/Checks/NamingUnderscoreCheck.vala
@@ -25,9 +25,11 @@ public class ValaLint.Checks.NamingUnderscoreCheck : Check {
         );
     }
 
-    public override void check (Vala.ArrayList<ParseResult?> parse_result, ref Vala.ArrayList<FormatMistake?> mistake_list) {
+    public override void check (Vala.ArrayList<ParseResult?> parse_result,
+                                ref Vala.ArrayList<FormatMistake?> mistake_list) {
         foreach (ParseResult r in parse_result) {
-            add_regex_mistake ("""[A-Z-]""", _("Expected variable name in underscore_convention"), r, ref mistake_list, 0, true);
+            add_regex_mistake ("""[A-Z-]""", _("Expected variable name in underscore_convention"), r,
+                               ref mistake_list, 0, true);
         }
     }
 }

--- a/lib/Checks/SpaceBeforeParenCheck.vala
+++ b/lib/Checks/SpaceBeforeParenCheck.vala
@@ -25,7 +25,8 @@ public class ValaLint.Checks.SpaceBeforeParenCheck : Check {
         );
     }
 
-    public override void check (Vala.ArrayList<ParseResult?> parse_result, ref Vala.ArrayList<FormatMistake?> mistake_list) {
+    public override void check (Vala.ArrayList<ParseResult?> parse_result,
+                                ref Vala.ArrayList<FormatMistake?> mistake_list) {
         foreach (ParseResult r in parse_result) {
             if (r.type == ParseType.DEFAULT) {
                 add_regex_mistake ("""[^_\s{\[\(\)!~]\(""", _("Expected space before paren"), r, ref mistake_list, 1);

--- a/lib/Checks/TabCheck.vala
+++ b/lib/Checks/TabCheck.vala
@@ -26,7 +26,8 @@ public class ValaLint.Checks.TabCheck : Check {
         );
     }
 
-    public override void check (Vala.ArrayList<ParseResult?> parse_result, ref Vala.ArrayList<FormatMistake?> mistake_list) {
+    public override void check (Vala.ArrayList<ParseResult?> parse_result,
+                                ref Vala.ArrayList<FormatMistake?> mistake_list) {
         foreach (ParseResult r in parse_result) {
             if (r.type == ParseType.DEFAULT || r.type == ParseType.COMMENT) {
                 add_regex_mistake ("""\t""", _("Expected spaces instead of tabs"), r, ref mistake_list, 0);

--- a/lib/Checks/TrailingWhitespaceCheck.vala
+++ b/lib/Checks/TrailingWhitespaceCheck.vala
@@ -27,7 +27,8 @@ public class ValaLint.Checks.TrailingWhitespaceCheck : Check {
         );
     }
 
-    public override void check (Vala.ArrayList<ParseResult?> parse_result, ref Vala.ArrayList<FormatMistake?> mistake_list) {
+    public override void check (Vala.ArrayList<ParseResult?> parse_result,
+                                ref Vala.ArrayList<FormatMistake?> mistake_list) {
         foreach (ParseResult r in parse_result) {
             if (r.type == ParseType.DEFAULT) {
                 add_regex_mistake ("""\h\n""", _("Unexpected whitespace at end of line"), r, ref mistake_list);


### PR DESCRIPTION
Fixes all code style warnings that are not in `/test`.