### PR TITLE
Check for Missing Spaces

### DIFF
--- a/lib/Check.vala
+++ b/lib/Check.vala
@@ -100,8 +100,8 @@ public abstract class ValaLint.Check : Object {
         mistakes.equal_func = (a, b) => {
             return a == b;
         };
-        
-        if (!mistakes.contains(mistake)) {
+
+        if (!mistakes.contains (mistake)) {
             mistakes.add (mistake);
         }
     }

--- a/lib/Check.vala
+++ b/lib/Check.vala
@@ -78,7 +78,7 @@ public abstract class ValaLint.Check : Object {
                 if (!single_mistake_in_line ||
                     (mistakes.is_empty || mistakes.last ().check != this || mistakes.last ().begin.line < line)) {
                     var location = Vala.SourceLocation (parse_result.begin.pos + pos_start, line, column);
-                    add_mistake ({ this, location, mistake });
+                    add_mistake ({ this, location, mistake }, ref mistakes);
                 }
 
                 if (return_after_mistake) {

--- a/lib/Check.vala
+++ b/lib/Check.vala
@@ -77,7 +77,7 @@ public abstract class ValaLint.Check : Object {
                 /* If single_mistake_in_line is true, add only one mistake of the same check per line */
                 if (!single_mistake_in_line ||
                     (mistakes.is_empty || mistakes.last ().check != this || mistakes.last ().line_index < line_pos)) {
-                    mistakes.add ({ this, line_pos, char_pos, mistake });
+                        add_mistake ({ this, line_pos, char_pos, mistake }, ref mistakes);
                 }
 
                 if (return_after_mistake) {
@@ -87,6 +87,22 @@ public abstract class ValaLint.Check : Object {
             }
         } catch {
             critical ("%s is not a valid Regex", pattern);
+        }
+    }
+
+    /**
+     * Adds a mistake to the mistake list and checks for duplicates.
+     *
+     * @param mistake The mistake.
+     * @param mistakes The mistakes list.
+     */
+    protected void add_mistake (FormatMistake mistake, ref Vala.ArrayList<FormatMistake?> mistakes) {
+        mistakes.equal_func = (a, b) => {
+            return a == b;
+        };
+        
+        if (!mistakes.contains(mistake)) {
+            mistakes.add (mistake);
         }
     }
 }

--- a/lib/Check.vala
+++ b/lib/Check.vala
@@ -96,7 +96,7 @@ public abstract class ValaLint.Check : Object {
      * @param mistake The mistake.
      * @param mistakes The mistakes list.
      */
-    protected void add_mistake (FormatMistake mistake,ref Vala.ArrayList<FormatMistake?> mistakes) {
+    protected void add_mistake (FormatMistake mistake, ref Vala.ArrayList<FormatMistake?> mistakes) {
         if (!mistakes.contains (mistake)) {
             mistakes.add (mistake);
         }

--- a/lib/Check.vala
+++ b/lib/Check.vala
@@ -96,11 +96,7 @@ public abstract class ValaLint.Check : Object {
      * @param mistake The mistake.
      * @param mistakes The mistakes list.
      */
-    protected void add_mistake (FormatMistake mistake, ref Vala.ArrayList<FormatMistake?> mistakes) {
-        mistakes.equal_func = (a, b) => {
-            return a == b;
-        };
-
+    protected void add_mistake (FormatMistake mistake,ref Vala.ArrayList<FormatMistake?> mistakes) {
         if (!mistakes.contains (mistake)) {
             mistakes.add (mistake);
         }

--- a/lib/Checks/LineLengthCheck.vala
+++ b/lib/Checks/LineLengthCheck.vala
@@ -39,8 +39,8 @@ public class ValaLint.Checks.LineLengthCheck : Check {
         foreach (string line in input.split ("\n")) {
             if (line.char_count () > MAXIMUM_CHARACTERS) {
                 int line_length = line.char_count ();
-                string message = @"Line exceeds limit of $MAXIMUM_CHARACTERS characters (currently $line_length characters)";
-                add_mistake ({ this, line_counter, MAXIMUM_CHARACTERS, message }, ref mistake_list);
+                string formatted_message = MESSAGE.printf (MAXIMUM_CHARACTERS, line_length);
+                add_mistake ({ this, line_counter, MAXIMUM_CHARACTERS, formatted_message }, ref mistake_list);
             }
             line_counter += 1;
         }

--- a/lib/Checks/LineLengthCheck.vala
+++ b/lib/Checks/LineLengthCheck.vala
@@ -38,7 +38,7 @@ public class ValaLint.Checks.LineLengthCheck : Check {
             if (line.char_count () > MAXIMUM_CHARACTERS) {
                 int line_length = line.char_count ();
                 string message = @"Line exceeds limit of $MAXIMUM_CHARACTERS characters (currently $line_length characters)";
-                mistake_list.add ({ this, line_counter, MAXIMUM_CHARACTERS, message });
+                add_mistake ({ this, line_counter, MAXIMUM_CHARACTERS, message }, ref mistake_list);
             }
             line_counter += 1;
         }

--- a/lib/Checks/NoSpaceCheck.vala
+++ b/lib/Checks/NoSpaceCheck.vala
@@ -46,7 +46,7 @@ public class ValaLint.Checks.NoSpaceCheck : Check {
 
                 char char_after = * (end.pos + 1);
                 if (char_after != ' ' && char_after != '\n' && char_after != ')') {
-                    mistake_list.add ({ this, end.line, end.column + 2, "Missing whitespace" });
+                    add_mistake ({ this, end.line, end.column + 2, "Missing whitespace" }, ref mistake_list);
                 }
             }
         }
@@ -57,12 +57,12 @@ public class ValaLint.Checks.NoSpaceCheck : Check {
         
         char char_before_operator = * (expr.left.source_reference.end.pos);
         if (char_before_operator != ' ' && char_before_operator != '\n' && char_before_operator != ')') {
-            mistake_list.add ({ this, expr.left.source_reference.end.line, expr.left.source_reference.end.column + 1, "Missing whitespace" });
+            add_mistake ({ this, expr.left.source_reference.end.line, expr.left.source_reference.end.column + 1, "Missing whitespace" }, ref mistake_list);
         }
 
         char char_after_operator = * (expr.right.source_reference.begin.pos - 1);
         if (char_after_operator != ' ' && char_after_operator != '\n' && char_after_operator != '(') {
-            mistake_list.add ({ this, expr.right.source_reference.begin.line, expr.right.source_reference.begin.column, "Missing whitespace" });
+            add_mistake ({ this, expr.right.source_reference.begin.line, expr.right.source_reference.begin.column, "Missing whitespace" }, ref mistake_list);
         }
     }
 }

--- a/lib/Checks/NoSpaceCheck.vala
+++ b/lib/Checks/NoSpaceCheck.vala
@@ -54,15 +54,17 @@ public class ValaLint.Checks.NoSpaceCheck : Check {
 
     public void check_binary_expression (Vala.BinaryExpression expr,
                                          ref Vala.ArrayList<FormatMistake?> mistake_list) {
-        
+
         char char_before_operator = * (expr.left.source_reference.end.pos);
         if (char_before_operator != ' ' && char_before_operator != '\n' && char_before_operator != ')') {
-            add_mistake ({ this, expr.left.source_reference.end.line, expr.left.source_reference.end.column + 1, "Missing whitespace" }, ref mistake_list);
+            var loc = expr.left.source_reference.end;
+            add_mistake ({ this, loc.line, loc.column + 1, "Missing whitespace" }, ref mistake_list);
         }
 
         char char_after_operator = * (expr.right.source_reference.begin.pos - 1);
         if (char_after_operator != ' ' && char_after_operator != '\n' && char_after_operator != '(') {
-            add_mistake ({ this, expr.right.source_reference.begin.line, expr.right.source_reference.begin.column, "Missing whitespace" }, ref mistake_list);
+            var loc = expr.right.source_reference.begin;
+            add_mistake ({ this, loc.line, loc.column, "Missing whitespace" }, ref mistake_list);
         }
     }
 }

--- a/lib/Checks/NoSpaceCheck.vala
+++ b/lib/Checks/NoSpaceCheck.vala
@@ -44,10 +44,17 @@ public class ValaLint.Checks.NoSpaceCheck : Check {
                     }
                 }
 
-                char char_after = * (end.pos + 1);
-                if (char_after != ' ' && char_after != '\n' && char_after != ')') {
+                // Move char to comma seperator
+                int offset = 0;
+                while (end.pos[offset] != ',') {
+                    offset += 1;
+                }
+                offset += 1;
+
+                if (end.pos[offset] != ' ' && end.pos[offset] != '\n') {
                     var loc = end;
-                    loc.column += 2;
+                    loc.pos += offset + 1;
+                    loc.column += offset + 1;
                     add_mistake ({ this, loc, "Missing whitespace" }, ref mistake_list);
                 }
             }
@@ -57,15 +64,15 @@ public class ValaLint.Checks.NoSpaceCheck : Check {
     public void check_binary_expression (Vala.BinaryExpression expr,
                                          ref Vala.ArrayList<FormatMistake?> mistake_list) {
 
-        char char_before_operator = * (expr.left.source_reference.end.pos);
-        if (char_before_operator != ' ' && char_before_operator != '\n' && char_before_operator != ')') {
+        char* char_before = expr.left.source_reference.end.pos;
+        if (char_before[0] != ' ' && char_before[0] != '\n' && char_before[0] != ')') {
             var loc = expr.left.source_reference.end;
             loc.column += 1;
             add_mistake ({ this, loc, "Missing whitespace" }, ref mistake_list);
         }
 
-        char char_after_operator = * (expr.right.source_reference.begin.pos - 1);
-        if (char_after_operator != ' ' && char_after_operator != '\n' && char_after_operator != '(') {
+        char* char_after = expr.right.source_reference.begin.pos - 1;
+        if (char_after[0] != ' ' && char_after[0] != '\n' && char_after[0] != '(') {
             var loc = expr.right.source_reference.begin;
             add_mistake ({ this, loc, "Missing whitespace" }, ref mistake_list);
         }

--- a/lib/Checks/NoSpaceCheck.vala
+++ b/lib/Checks/NoSpaceCheck.vala
@@ -46,7 +46,9 @@ public class ValaLint.Checks.NoSpaceCheck : Check {
 
                 char char_after = * (end.pos + 1);
                 if (char_after != ' ' && char_after != '\n' && char_after != ')') {
-                    add_mistake ({ this, end.line, end.column + 2, "Missing whitespace" }, ref mistake_list);
+                    var loc = end;
+                    loc.column += 2;
+                    add_mistake ({ this, loc, "Missing whitespace" }, ref mistake_list);
                 }
             }
         }
@@ -58,13 +60,14 @@ public class ValaLint.Checks.NoSpaceCheck : Check {
         char char_before_operator = * (expr.left.source_reference.end.pos);
         if (char_before_operator != ' ' && char_before_operator != '\n' && char_before_operator != ')') {
             var loc = expr.left.source_reference.end;
-            add_mistake ({ this, loc.line, loc.column + 1, "Missing whitespace" }, ref mistake_list);
+            loc.column += 1;
+            add_mistake ({ this, loc, "Missing whitespace" }, ref mistake_list);
         }
 
         char char_after_operator = * (expr.right.source_reference.begin.pos - 1);
         if (char_after_operator != ' ' && char_after_operator != '\n' && char_after_operator != '(') {
             var loc = expr.right.source_reference.begin;
-            add_mistake ({ this, loc.line, loc.column, "Missing whitespace" }, ref mistake_list);
+            add_mistake ({ this, loc, "Missing whitespace" }, ref mistake_list);
         }
     }
 }

--- a/lib/Checks/NoSpaceCheck.vala
+++ b/lib/Checks/NoSpaceCheck.vala
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2018 elementary LLC. (https://github.com/elementary/vala-lint)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ */
+
+public class ValaLint.Checks.NoSpaceCheck : Check {
+    public NoSpaceCheck () {
+        Object (
+            title: _("no-space"),
+            description: _("Checks for missing spaces")
+        );
+    }
+
+    public override void check (Vala.ArrayList<ParseResult?> parse_result,
+                                ref Vala.ArrayList<FormatMistake?> mistake_list) {
+
+    }
+
+    public void check_list (Vala.List<Vala.CodeNode?> list,
+                            ref Vala.ArrayList<FormatMistake?> mistake_list) {
+        if (list.size > 1) {
+            for (int i = 0; i < list.size - 1; i++) {
+                var expr = list[i];
+                var end = expr.source_reference.end;
+
+                if (expr is Vala.Parameter) {
+                    var parameter = expr as Vala.Parameter;
+                    if (parameter.initializer != null) {
+                        end = parameter.initializer.source_reference.end;
+                    }
+                }
+
+                char char_after = * (end.pos + 1);
+                if (char_after != ' ' && char_after != '\n' && char_after != ')') {
+                    mistake_list.add ({ this, end.line, end.column + 2, "Missing whitespace" });
+                }
+            }
+        }
+    }
+
+    public void check_binary_expression (Vala.BinaryExpression expr,
+                                         ref Vala.ArrayList<FormatMistake?> mistake_list) {
+        
+        char char_before_operator = * (expr.left.source_reference.end.pos);
+        if (char_before_operator != ' ' && char_before_operator != '\n' && char_before_operator != ')') {
+            mistake_list.add ({ this, expr.left.source_reference.end.line, expr.left.source_reference.end.column + 1, "Missing whitespace" });
+        }
+
+        char char_after_operator = * (expr.right.source_reference.begin.pos - 1);
+        if (char_after_operator != ' ' && char_after_operator != '\n' && char_after_operator != '(') {
+            mistake_list.add ({ this, expr.right.source_reference.begin.line, expr.right.source_reference.begin.column, "Missing whitespace" });
+        }
+    }
+}

--- a/lib/FormatMistake.vala
+++ b/lib/FormatMistake.vala
@@ -24,4 +24,13 @@ public struct ValaLint.FormatMistake {
     public int line_index;
     public int char_index;
     public string mistake;
+
+    public bool equal_to (FormatMistake b) {
+        return (
+            check == b.check
+            && line_index == b.line_index
+            && char_index == b.char_index
+            && mistake == b.mistake
+        );
+    }
 }

--- a/lib/FormatMistake.vala
+++ b/lib/FormatMistake.vala
@@ -27,8 +27,7 @@ public struct ValaLint.FormatMistake {
     public bool equal_to (FormatMistake b) {
         return (
             check == b.check
-            && line_index == b.line_index
-            && char_index == b.char_index
+            && begin == b.begin
             && mistake == b.mistake
         );
     }

--- a/lib/Linter.vala
+++ b/lib/Linter.vala
@@ -43,6 +43,7 @@ public class ValaLint.Linter : Object {
         visitor.naming_camel_case_check = new Checks.NamingCamelCaseCheck ();
         visitor.naming_underscore_check = new Checks.NamingUnderscoreCheck ();
         visitor.no_space_check = new Checks.NoSpaceCheck ();
+        
         visitor.checks = new Vala.ArrayList<Check> ();
         visitor.checks.add (visitor.naming_all_caps_check);
         visitor.checks.add (visitor.naming_camel_case_check);

--- a/lib/Linter.vala
+++ b/lib/Linter.vala
@@ -21,6 +21,9 @@
 
 public class ValaLint.Linter : Object {
 
+    /* Property whether the mistakes can be disabled by inline comments. */
+    public bool disable_mistakes { get; set; default = true; }
+
     /* Checks which work on the result of our own ValaLint.Parser. */
     public Vala.ArrayList<Check> global_checks { get; set; }
 
@@ -97,7 +100,9 @@ public class ValaLint.Linter : Object {
             var disabler = new ValaLint.Disabler ();
             Vala.ArrayList<ValaLint.DisableResult?> disable_results = disabler.parse (parse_result);
 
-            mistake_list = disabler.filter_mistakes (mistake_list, disable_results);
+            if (disable_mistakes) {
+                mistake_list = disabler.filter_mistakes (mistake_list, disable_results);
+            }
 
             mistake_list.sort ((a, b) => {
                 if (a.begin.line == b.begin.line) {

--- a/lib/Linter.vala
+++ b/lib/Linter.vala
@@ -41,10 +41,12 @@ public class ValaLint.Linter : Object {
         visitor.naming_all_caps_check = new Checks.NamingAllCapsCheck ();
         visitor.naming_camel_case_check = new Checks.NamingCamelCaseCheck ();
         visitor.naming_underscore_check = new Checks.NamingUnderscoreCheck ();
+        visitor.no_space_check = new Checks.NoSpaceCheck ();
         visitor.checks = new Vala.ArrayList<Check> ();
         visitor.checks.add (visitor.naming_all_caps_check);
         visitor.checks.add (visitor.naming_camel_case_check);
         visitor.checks.add (visitor.naming_underscore_check);
+        visitor.checks.add (visitor.no_space_check);
     }
 
     public Linter.with_check (Check check) {

--- a/lib/Linter.vala
+++ b/lib/Linter.vala
@@ -43,7 +43,7 @@ public class ValaLint.Linter : Object {
         visitor.naming_camel_case_check = new Checks.NamingCamelCaseCheck ();
         visitor.naming_underscore_check = new Checks.NamingUnderscoreCheck ();
         visitor.no_space_check = new Checks.NoSpaceCheck ();
-        
+
         visitor.checks = new Vala.ArrayList<Check> ();
         visitor.checks.add (visitor.naming_all_caps_check);
         visitor.checks.add (visitor.naming_camel_case_check);

--- a/lib/Linter.vala
+++ b/lib/Linter.vala
@@ -61,7 +61,7 @@ public class ValaLint.Linter : Object {
     }
 
     public Vala.ArrayList<FormatMistake?> run_checks_for_file (File file) throws Error, IOError {
-        var mistake_list = new Vala.ArrayList<FormatMistake?> ();
+        var mistake_list = new Vala.ArrayList<FormatMistake?> ((a, b) => a.equal_to (b));
 
         var context = new Vala.CodeContext ();
         var reporter = new Reporter (mistake_list);

--- a/lib/ValaVisitor.vala
+++ b/lib/ValaVisitor.vala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 elementary LLC. (https://github.com/elementary/vala-lint)
+ * Copyright (c) 2018-2019 elementary LLC. (https://github.com/elementary/vala-lint)
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public
@@ -25,6 +25,7 @@ class ValaLint.Visitor : Vala.CodeVisitor {
     public Checks.NamingAllCapsCheck naming_all_caps_check;
     public Checks.NamingCamelCaseCheck naming_camel_case_check;
     public Checks.NamingUnderscoreCheck naming_underscore_check;
+    public Checks.NoSpaceCheck no_space_check;
 
     public void set_mistake_list (Vala.ArrayList<FormatMistake?> mistake_list) {
         this.mistake_list = mistake_list;
@@ -80,16 +81,25 @@ class ValaLint.Visitor : Vala.CodeVisitor {
 
     public override void visit_constant (Vala.Constant c) {
         naming_all_caps_check.check (string_parsed (c.name, c.source_reference), ref mistake_list);
+
         c.accept_children (this);
     }
 
     public override void visit_field (Vala.Field f) {
         naming_underscore_check.check (string_parsed (f.name, f.source_reference), ref mistake_list);
+
         f.accept_children (this);
     }
 
     public override void visit_method (Vala.Method m) {
         naming_underscore_check.check (string_parsed (m.name, m.source_reference), ref mistake_list);
+
+        no_space_check.check_list (m.get_parameters (), ref mistake_list);
+
+        var error_types = new Vala.ArrayList<Vala.DataType?> ();
+        m.get_error_types (error_types);
+        no_space_check.check_list (error_types, ref mistake_list);
+
         m.accept_children (this);
     }
 
@@ -99,6 +109,7 @@ class ValaLint.Visitor : Vala.CodeVisitor {
 
     public override void visit_formal_parameter (Vala.Parameter p) {
         naming_underscore_check.check (string_parsed (p.name, p.source_reference), ref mistake_list);
+
         p.accept_children (this);
     }
 
@@ -150,6 +161,8 @@ class ValaLint.Visitor : Vala.CodeVisitor {
     }
 
     public override void visit_initializer_list (Vala.InitializerList list) {
+        no_space_check.check_list (list.get_initializers (), ref mistake_list);
+
         list.accept_children (this);
     }
 
@@ -272,6 +285,8 @@ class ValaLint.Visitor : Vala.CodeVisitor {
     }
 
     public override void visit_tuple (Vala.Tuple tuple) {
+        no_space_check.check_list (tuple.get_expressions (), ref mistake_list);
+
         tuple.accept_children (this);
     }
 
@@ -284,6 +299,8 @@ class ValaLint.Visitor : Vala.CodeVisitor {
     }
 
     public override void visit_method_call (Vala.MethodCall expr) {
+        no_space_check.check_list (expr.get_argument_list (), ref mistake_list);
+
         expr.accept_children (this);
     }
 
@@ -340,6 +357,8 @@ class ValaLint.Visitor : Vala.CodeVisitor {
     }
 
     public override void visit_binary_expression (Vala.BinaryExpression expr) {
+        no_space_check.check_binary_expression (expr, ref mistake_list);
+
         expr.accept_children (this);
     }
 
@@ -352,6 +371,8 @@ class ValaLint.Visitor : Vala.CodeVisitor {
     }
 
     public override void visit_lambda_expression (Vala.LambdaExpression expr) {
+        no_space_check.check_list (expr.get_parameters (), ref mistake_list);
+
         expr.accept_children (this);
     }
 

--- a/lib/ValaVisitor.vala
+++ b/lib/ValaVisitor.vala
@@ -95,9 +95,10 @@ class ValaLint.Visitor : Vala.CodeVisitor {
 
         no_space_check.check_list (m.get_parameters (), ref mistake_list);
 
-        var error_types = new Vala.ArrayList<Vala.DataType?> ();
-        m.get_error_types (error_types);
-        no_space_check.check_list (error_types, ref mistake_list);
+        /* Error types depend on the vala version. */
+        //  var error_types = new Vala.ArrayList<Vala.DataType?> ();
+        //  m.get_error_types (error_types);
+        //  no_space_check.check_list (error_types, ref mistake_list);
 
         m.accept_children (this);
     }

--- a/lib/ValaVisitor.vala
+++ b/lib/ValaVisitor.vala
@@ -38,8 +38,7 @@ class ValaLint.Visitor : Vala.CodeVisitor {
     public override void visit_namespace (Vala.Namespace ns) {
         naming_camel_case_check.check (string_parsed (ns.name, ns.source_reference), ref mistake_list);
 
-        /* Dont visit namespaces, as double visiting can occur. */
-        // ns.accept_children (this);
+        ns.accept_children (this);
     }
 
     public override void visit_class (Vala.Class cl) {

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -14,6 +14,7 @@ vala_linter_files = files(
     'Checks/NamingAllCapsCheck.vala',
     'Checks/NamingCamelCaseCheck.vala',
     'Checks/NamingUnderscoreCheck.vala',
+    'Checks/NoSpaceCheck.vala',
     'Checks/SpaceBeforeParenCheck.vala',
     'Checks/TabCheck.vala',
     'Checks/TrailingWhitespaceCheck.vala',

--- a/test/FileTest.vala
+++ b/test/FileTest.vala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2016-2018 elementary LLC. (https://github.com/elementary/vala-lint)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ */
+
+class FileTest : GLib.Object {
+
+    public static int main (string[] args) {
+        var linter = new ValaLint.Linter ();
+        linter.disable_mistakes = false;
+        Vala.ArrayList<ValaLint.FormatMistake?> mistakes;
+
+        try {
+            mistakes = linter.run_checks_for_file (File.new_for_path ("../test/files/pass.vala"));
+            assert (mistakes.size == 0);
+        } catch (Error e) {
+            critical ("Error: %s while linting pass file\n", e.message);
+        }
+
+        try {
+            mistakes = linter.run_checks_for_file (File.new_for_path ("../test/files/warnings.vala"));
+            assert (mistakes.size == 2);
+            assert (mistakes[0].check.title == "space-before-paren");
+            assert (mistakes[1].check.title == "no-space");
+            //  assert (mistakes[2].check.title == "trailing-newlines");
+        } catch (Error e) {
+            critical ("Error: %s while linting warnings file\n", e.message);
+        }
+
+        return 0;
+    }
+}

--- a/test/files/pass.vala
+++ b/test/files/pass.vala
@@ -1,0 +1,7 @@
+class FileTest : GLib.Object {
+
+    public static int main (string[] args) {
+
+        return 0;
+    }
+}

--- a/test/files/warnings.vala
+++ b/test/files/warnings.vala
@@ -1,0 +1,11 @@
+class FileTest : GLib.Object {
+
+    public static int main(string[] args) { // vala-lint=space-before-paren
+
+        return 0;
+    }
+
+    public void test (string a,string b) { // vala-lint=no-space
+
+    }
+} // vala-lint=trailing-newlines

--- a/test/meson.build
+++ b/test/meson.build
@@ -7,4 +7,14 @@ unit_test = executable(
     ]
 )
 
+file_test = executable(
+    'file-test',
+    'FileTest.vala',
+    dependencies: [
+        vala_linter_dep,
+        posix_dep
+    ]
+)
+
 test('vala lint unit test', unit_test)
+test('vala lint file test', file_test)


### PR DESCRIPTION
This PR adds a `no-spaces`check for missing spaces around parameters, initializer lists and binary operators, fixing issue #4. 