### PR TITLE
Check for Trailing Newline

### DIFF
--- a/lib/Checks/TrailingNewlinesCheck.vala
+++ b/lib/Checks/TrailingNewlinesCheck.vala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2016-2019 elementary LLC. (https://github.com/elementary/vala-lint)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ */
+
+public class ValaLint.Checks.TrailingNewlinesCheck : Check {
+    public TrailingNewlinesCheck () {
+        Object (
+            title: _("trailing-newlines"),
+            description:_("Checks for a single newline at the end of files")
+        );
+    }
+
+    public override void check (Vala.ArrayList<ParseResult?> parse_result,
+                                ref Vala.ArrayList<FormatMistake?> mistake_list) {
+        ParseResult r_last = parse_result.last ();
+        if (r_last.type == ParseType.DEFAULT) {
+            add_regex_mistake ("""[^\n]\z""", _("Missing newline at the end of file"), r_last, ref mistake_list);
+            add_regex_mistake ("""\n{2,}\z""", _("Multiple newlines at the end of file"), r_last, ref mistake_list);
+        }
+    }
+}

--- a/lib/Checks/TrailingNewlinesCheck.vala
+++ b/lib/Checks/TrailingNewlinesCheck.vala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 elementary LLC. (https://github.com/elementary/vala-lint)
+ * Copyright (c) 2019 elementary LLC. (https://github.com/elementary/vala-lint)
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public

--- a/lib/Linter.vala
+++ b/lib/Linter.vala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 elementary LLC. (https://github.com/elementary/vala-lint)
+ * Copyright (c) 2016-2019 elementary LLC. (https://github.com/elementary/vala-lint)
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public
@@ -35,6 +35,7 @@ public class ValaLint.Linter : Object {
         global_checks.add (new Checks.LineLengthCheck ());
         global_checks.add (new Checks.SpaceBeforeParenCheck ());
         global_checks.add (new Checks.TabCheck ());
+        global_checks.add (new Checks.TrailingNewlinesCheck ());
         global_checks.add (new Checks.TrailingWhitespaceCheck ());
 
         visitor = new ValaLint.Visitor ();

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -16,6 +16,7 @@ vala_linter_files = files(
     'Checks/NamingUnderscoreCheck.vala',
     'Checks/SpaceBeforeParenCheck.vala',
     'Checks/TabCheck.vala',
+    'Checks/TrailingNewlinesCheck.vala',
     'Checks/TrailingWhitespaceCheck.vala',
 )
 

--- a/test/UnitTest.vala
+++ b/test/UnitTest.vala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 elementary LLC. (https://github.com/elementary/vala-lint)
+ * Copyright (c) 2016-2019 elementary LLC. (https://github.com/elementary/vala-lint)
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public
@@ -81,6 +81,12 @@ class UnitTest : GLib.Object {
         var tab_check = new ValaLint.Checks.TabCheck ();
         assert_pass (tab_check, "lorem ipsum");
         assert_warning (tab_check, "lorem	ipsum");
+
+        var trailing_newlines_check = new ValaLint.Checks.TrailingNewlinesCheck ();
+        assert_pass (trailing_newlines_check, "lorem ipsum\n");
+        assert_warning (trailing_newlines_check, "lorem ipsum", 11);
+        assert_warning (trailing_newlines_check, "lorem ipsum ", 12);
+        assert_warning (trailing_newlines_check, "lorem ipsum\n\n");
 
         var trailing_whitespace_check = new ValaLint.Checks.TrailingWhitespaceCheck ();
         assert_pass (trailing_whitespace_check, "lorem ipsum");


### PR DESCRIPTION
Checks for a single newline at the end of the file. This is not explicitly in the elementary code style, but it is a common rule for linters.